### PR TITLE
[codex] Fix production runtime issues

### DIFF
--- a/commands/files.js
+++ b/commands/files.js
@@ -4,5 +4,5 @@ export const data = new SlashCommandBuilder()
     .setName('files')
     .setDescription('Replies with the URL for our Files Archive (contains mostly legacy files).');
 export async function execute(interaction) {
-    await interaction.reply("Here's the link for the File Archive: https://files.hondatabase.com");
+    await interaction.reply("Here's the link for the File Archive: https://files.hondabase.com");
 }

--- a/commands/pdf.js
+++ b/commands/pdf.js
@@ -1,5 +1,5 @@
 /*
-	This command is responsible for searching for PDF files on the "pdf-manuals" GitHub repository (hondatabase/pdf-manuals)
+	This command is responsible for searching for PDF files in the Hondabase files archive.
 	..and sending a list of matches to the user
 */
 
@@ -7,14 +7,13 @@ import path from 'path';
 import { Octokit } from '@octokit/rest';
 import { SlashCommandBuilder } from 'discord.js';
 
-import { client } from '../index.js';
 import { GITHUB_ORG_URL } from '../config.js';
 
 let pdfFiles = [];
 
 async function fetchPDFFiles(path = '') {
 	try {
-		const { data } = await new Octokit().repos.getContent({ owner: 'hondatabase', repo: 'pdf-manuals', path });
+		const { data } = await new Octokit().repos.getContent({ owner: 'hondabase', repo: 'files-archive', path });
 
 		let files = [];
 
@@ -36,7 +35,7 @@ async function fetchPDFFiles(path = '') {
 
 export const data = new SlashCommandBuilder()
 	.setName('pdf')
-	.setDescription('Searches for a PDF file on the "pdf-manuals" GitHub repository.')
+	.setDescription('Searches for a PDF file in the Hondabase files archive.')
 	.addStringOption(option => option.setName('query')
 		.setDescription('The search query')
 		.setRequired(true)
@@ -44,26 +43,17 @@ export const data = new SlashCommandBuilder()
 export async function execute(interaction) {
 	const query = interaction.options.getString('query').toLowerCase().split(' ');
 
+	if (pdfFiles.length === 0) pdfFiles = await fetchPDFFiles();
 	if (pdfFiles.length === 0) return interaction.reply({ content: 'I currently don\'t have access to GitHub. Try again later.', ephemeral: true });
 
 	const matches = pdfFiles.filter(file => query.every(word => file.toLowerCase().includes(word)));
 
 	if (matches.length === 0) return interaction.reply({ content: 'No matches found.', ephemeral: true });
 
-	const fileList = matches.map(filePath => `[${path.basename(filePath).split('.')[0]}](${GITHUB_ORG_URL}pdf-manuals/raw/main/${filePath.replace(/ /g, '%20')})`).join('\n');
+	const fileList = matches.map(filePath => `[${path.basename(filePath).split('.')[0]}](${GITHUB_ORG_URL}files-archive/raw/main/${filePath.replace(/ /g, '%20')})`).join('\n');
 	const prefix   = `**PDFs that match**: \`${query.join(' ')}\`\n`;
 
 	if (prefix.length + fileList.length > 2000) return interaction.reply({ content: 'Too many matches found. Please refine your search.', ephemeral: true });
 
 	await interaction.reply(prefix + fileList);
 }
-
-client.on('ready', () => {
-	console.log('Fetching PDF files...');
-	fetchPDFFiles()
-		.then(files => {
-			pdfFiles = files;
-			console.log(files.length + ' PDF files fetched.');
-		})
-		.catch(() => console.log('Failed to fetch PDF files.'));
-});

--- a/commands/request-article.js
+++ b/commands/request-article.js
@@ -72,7 +72,7 @@ export async function execute(interaction) {
 }
 
 async function saveArticleRequest(articleData) {
-    const filePath = join(__dirname, '..', 'data', 'articles.json');
+    const filePath = join(process.cwd(), 'data', 'articles.json');
     try {
         let articles = [];
         try {

--- a/config.js
+++ b/config.js
@@ -3,13 +3,13 @@ dotenv.config();
 
 export const BOT_CLIENT_ID = process.env.BOT_CLIENT_ID
 export const BOT_TOKEN = process.env.BOT_TOKEN
-export const INVITE_URL = "http://discord.hondatabase.com"
+export const INVITE_URL = "https://discord.hondabase.com"
 export const STAFF_CHANNEL_ID = process.env.STAFF_CHANNEL_ID
 export const STAFF_ROLE_ID = process.env.STAFF_ROLE_ID
 export const HANGOUT_CHANNEL_ID = process.env.HANGOUT_CHANNEL_ID
 export const ARTICLE_REQUEST_CHANNEL_ID = process.env.ARTICLE_REQUEST_CHANNEL_ID
 export const ARTICLE_REQUEST_CHANNEL_TOPARTICLES_MESSAGE_ID = process.env.ARTICLE_REQUEST_CHANNEL_TOPARTICLES_MESSAGE_ID
-export const GITHUB_ORG_URL = "https://github.com/hondatabase/"
+export const GITHUB_ORG_URL = "https://github.com/hondabase/"
 
 export const MYSQL_USER = process.env.MYSQL_USER
 export const MYSQL_PASSWORD = process.env.MYSQL_PASSWORD

--- a/events/guildMemberAdd.js
+++ b/events/guildMemberAdd.js
@@ -1,4 +1,5 @@
 import getBlacklist from '../utils/getBlacklist.js';
+import { logUserActivity } from '../utils/database.js';
 import { STAFF_CHANNEL_ID } from '../config.js';
 
 export async function execute(client, member) {

--- a/index.js
+++ b/index.js
@@ -20,6 +20,8 @@ client.commands     = new Collection();
 client.guildInvites = new Collection();
 
 function sendWebhook(message) {
+    if (!WATCHDOG_WEBHOOK_URL) return;
+
     fetch('https://discord.com/api/webhooks/' + WATCHDOG_WEBHOOK_URL, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},

--- a/utils/getBlacklist.js
+++ b/utils/getBlacklist.js
@@ -2,7 +2,7 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 
 export default async () => {
-    const blacklistPath = join(__dirname, '..', 'data', 'blacklist.json');
+    const blacklistPath = join(process.cwd(), 'data', 'blacklist.json');
     try {
         const data = await fs.readFile(blacklistPath, 'utf8');
         return JSON.parse(data);


### PR DESCRIPTION
## Summary

- update stale `hondatabase` URLs and point PDF search at `hondabase/files-archive`
- prevent slash-command deployment from starting the full bot process
- fix ESM runtime failures caused by `__dirname` usage
- import missing activity logger and make watchdog notifications optional

## Why

These issues were discovered while deploying the bot as a systemd service. They prevented clean command deployment, broke JSON-backed features under ESM, and referenced repositories and domains that no longer exist.

## Validation

- checked all JavaScript files with `node --check`
- registered global slash commands successfully
- initialized the MySQL schema successfully
- verified the systemd service remains active with zero restarts
